### PR TITLE
Add ability to switch off mouse scaling.

### DIFF
--- a/x2x.1
+++ b/x2x.1
@@ -249,6 +249,15 @@ Override the title of the control window (useful when running over ssh).
 .B \-copyright
 .IP
 Prints the full copyright for the x2x code.
+.TP
+.B \-noscale
+.IP
+This option turns off the mouse scaling.  In some circumstances, the
+remote screen is so different in physical size or resolution that the
+normal mouse scaling applied by x2x distorts the mouse movement so much
+as to be practially unusable.  Note: this is only useful if the remote
+screen is lower resolution than the local screen and also causes the
+remote mouse pointer to warp around when it hits the edges.
 .SH EXAMPLES
 Calling the system whose keyboard is to be used "primary" and the
 other system "secondary", you need to specify either \-from

--- a/x2x.c
+++ b/x2x.c
@@ -373,6 +373,7 @@ static Bool    doDpmsMouse  = False;
 static int     logicalOffset= 0;
 static int     nButtons     = 0;
 static KeySym  buttonmap[N_BUTTONS + 1][MAX_BUTTONMAPEVENTS + 1];
+static Bool    noScale      = False;
 
 #ifdef WIN_2_X
 /* These are used to allow pointer comparisons */
@@ -731,6 +732,8 @@ char **argv;
       triggerw = atoi(argv[arg]);
     } else if (!strcasecmp(argv[arg], "-copyright")) {
       puts(lawyerese);
+    } else if (!strcasecmp(argv[arg], "-noscale")) {
+      noScale = True;
     } else {
       Usage();
     } /* END if... */
@@ -1324,13 +1327,31 @@ PDPYINFO pDpyInfo;
     pDpyInfo->yTables[screenNum] = yTable =
       (short *)xmalloc(sizeof(short) * fromHeight);
 
-    /* vertical conversion table */
-    for (counter = 0; counter < fromHeight; ++counter)
-      yTable[counter] = (counter * toHeight) / fromHeight;
+    if (noScale) {
+        /* TODO:
+            - the fake tables should be built as "starting ignored", 1:1 map
+              region and "ending ignored".  Then the rest of the code would
+              need to be taught to disallow mouse movements in the two ignored
+              areas.  This would stop the mouse wrap-around that the simple
+              tables below result in.
+        */
 
-    /* horizontal conversion table entries */
-    for (counter = 0; counter < fromWidth; ++counter)
-      xTable[counter] = (counter * toWidth) / fromWidth;
+        /* fake vertical conversion table */
+        for (counter = 0; counter < fromHeight; ++counter)
+          yTable[counter] = counter % (toHeight - 1);
+
+        /* fake horizontal conversion table entries */
+        for (counter = 0; counter < fromWidth; ++counter)
+          xTable[counter] = counter % (toWidth - 1);
+    } else {
+        /* vertical conversion table */
+        for (counter = 0; counter < fromHeight; ++counter)
+          yTable[counter] = (counter * toHeight) / fromHeight;
+
+        /* horizontal conversion table entries */
+        for (counter = 0; counter < fromWidth; ++counter)
+          xTable[counter] = (counter * toWidth) / fromWidth;
+    }
 
     /* adjustment for boundaries */
     if (vertical) {


### PR DESCRIPTION
The scaling made x2x basically unusable when it was used with a smaller
remote monitor with significantly less pixels than the local one.

I know that there are issues with the quick-fix method that I have used, but am sending my patches through anyway because I dont have as simple an answer for the warping I have caused