### PR TITLE
Fix for issue #5 by allowing complete region specification

### DIFF
--- a/x2x.1
+++ b/x2x.1
@@ -258,6 +258,27 @@ normal mouse scaling applied by x2x distorts the mouse movement so much
 as to be practially unusable.  Note: this is only useful if the remote
 screen is lower resolution than the local screen and also causes the
 remote mouse pointer to warp around when it hits the edges.
+.TP
+.B \-completeregionleft
+.IP
+Describes leftmost coordinate of complete rectangle region in from-display.  If
+from-display is configured with multiple monitors and they have different
+resolution, few regions that does not belongs to any monitor becomes dead space
+that mouse cannot move in.  In the case, the dead space can be mapped to legal
+region of to-display.  If complete region in from-display is specified, X2X
+maps only complete region to to-display and avoid the dead, but legal regions.
+.TP
+.B \-completeregionright
+.IP
+Describes rightmost coordinate of complete rectangle region in from-display.
+.TP
+.B \-completeregionup
+.IP
+Describes uppermost coordinate of complete rectangle region in from-display.
+.TP
+.B \-completeregionlow
+.IP
+Describes lowermost coordinate of complete rectangle region in from-display.
 .SH EXAMPLES
 Calling the system whose keyboard is to be used "primary" and the
 other system "secondary", you need to specify either \-from


### PR DESCRIPTION
If from-display is configured with multiple monitors and they have
different resolution, few regions that don't belong to any monitor
becomes dad space that mouse cannot move in.  In the case, the dead
space becomes mapped to legal region of to-display.  As consequence,
user cannot move mouse into every region of to-display.  Same problem
has reported about 5 years ago[1].

This commit fixes the problem by let user specify complete rectangle
region of from-display explicitly.  If the region specified, x2x maps
only the complete region to to-display.

[1] https://github.com/dottedmag/x2x/issues/5

Signed-off-by: SeongJae Park sj38.park@gmail.com
