### PR TITLE
Talk like a dock

### DIFF
--- a/x2x.c
+++ b/x2x.c
@@ -235,6 +235,7 @@ typedef struct {
   int     selRevFrom;
   GC      textGC;
   Atom    wmpAtom, wmdwAtom;
+  Atom    netWmWindowTypeAtom, netWmWindowTypeDockAtom;
   Cursor  grabCursor;
   Font    fid;
   int     width, height, twidth, theight, tascent;
@@ -1208,6 +1209,13 @@ PDPYINFO pDpyInfo;
                     vertical ? triggerw : fromHeight - (2*triggerw),
                     0, 0, InputOnly, 0,
                     CWOverrideRedirect, &xswa);
+
+    pDpyInfo->netWmWindowTypeAtom = XInternAtom(fromDpy, "_NET_WM_WINDOW_TYPE", True);
+    pDpyInfo->netWmWindowTypeDockAtom = XInternAtom(fromDpy, "_NET_WM_WINDOW_TYPE_DOCK", True);
+    XChangeProperty(fromDpy, trigger, pDpyInfo->netWmWindowTypeAtom,
+                    XA_ATOM, 32, PropModeReplace,
+                    (unsigned char *)&pDpyInfo->netWmWindowTypeDockAtom, 1);
+
 #ifdef WIN_2_X
     }
 #endif

--- a/x2x.c
+++ b/x2x.c
@@ -2543,12 +2543,12 @@ PDPYINFO pDpyInfo;
           if ((keycode = XKeysymToKeycode(pShadow->dpy, pFake->thing))) {
             XTestFakeKeyEvent(pShadow->dpy, keycode, False, 0);
 	    pShadow->flush = True;
-            debug("key 0x%x up\n", pFake->thing);
+            debug("key 0x%lx up\n", (unsigned long)pFake->thing);
           } /* END if */
         } else { /* button goes up */
           XTestFakeButtonEvent(pShadow->dpy, pFake->thing, False, 0);
 	  pShadow->flush = True;
-          debug("button %d up\n", pFake->thing);
+          debug("button %ld up\n", (long)pFake->thing);
         } /* END if/else */
       } /* END for */
 


### PR DESCRIPTION
Running a modern compositing window manager (gnome-shell 3.18.5, mutter 3.18.3), x2x's trigger window tends to become obscured by maximized windows and windows overlapping the triggering edge, even with -resurface. VisibilityNotify events seem not to be generated with such window managers, and in any case the X server is not guaranteed to send them to InputOnly windows.

The attached change work around this by setting an EWMH property that informs the window manager that the trigger window is a dock and should be kept above other windows. Also included is a fix to a minor word-size issue in some debug messages.