### PR TITLE
Fixed issue https://github.com/dottedmag/x2x/issues/24

### DIFF
--- a/x2x.1
+++ b/x2x.1
@@ -197,6 +197,17 @@ another window ever obscures it.  This option can cause really nasty
 behavior if another application tries to do the same thing.  Useful for
 login scripts.
 .TP
+.B \-win-output
+.IP
+Makes the small window ("trigger window") on the side of the "from" display
+an InputOutput window instead of an InputOnly window. Visibility notification
+events are never generated for InputOnly window, therefore -resurface would
+not work for InputOnly window. Use -win-output together with -resurface.
+.TP
+.B \-win-transparent
+.IP
+Makes the small window ("trigger window") transparent. Use with -win-output option.
+.TP
 .B \-struts
 .IP
 Advertise struts in _NET_WM_STRUT


### PR DESCRIPTION
x2x won't move mouse to secondary screen if a primary window is too close to the edge, on Ubuntu 18.04. The problem was that the trigger window was a InputOnly class window, which does not generate visibility events (according to document). 

This version added two options to address this issue. "-win-output" makes the trigger window an InputOutput window so visibility events are generated for the trigger window, and "-win-transparent" makes the trigger window transparent, so not to bother users. Use these two options or at least the "-win-output" option to solve the problem. Otherwise, x2x behaves the same as the original without the extra option.