### PR TITLE
Update x2x.c

### DIFF
--- a/x2x.c
+++ b/x2x.c
@@ -1230,13 +1230,14 @@ PDPYINFO pDpyInfo;
        screen real estate --09/29/99 gjb */
     /* make it InputOutput when argument -win-output presents,
        so to get window visibility change event and make -resurface work */
+    /* make it InputOutput so to make -resurface work*/ 
     trigger = pDpyInfo->trigger =
       XCreateWindow(fromDpy, root,
                     vertical ? triggerw : triggerLoc,
                     vertical ? triggerLoc : triggerw,
                     vertical ? fromWidth - (2*triggerw) : triggerw,
                     vertical ? triggerw : fromHeight - (2*triggerw),
-                    0, 0, doInputOnly?InputOnly:InputOutput, 0,
+                    0, 0, InputOutput, 0,
                     CWOverrideRedirect, &xswa);
 
     pDpyInfo->netWmWindowTypeAtom = XInternAtom(fromDpy, "_NET_WM_WINDOW_TYPE", True);


### PR DESCRIPTION
When x2x windows are obscured by another window, they never come back upfront even when -resurface or -struts options are used.

I was able to fix the issue by setting the class of the x2x windows to InputOutput instead of InputOnly (at x2x.c:1270).
InputOnly windows never receive the VisibilityNotify event, thus the ProcessVisibility() callback is never called.
Xlib documentation confirming : https://tronche.com/gui/x/xlib/events/window-state-change/visibility.html
